### PR TITLE
feat : 공개 카테고리 목록 조회 구현

### DIFF
--- a/src/main/java/com/googongill/aditory/common/code/SuccessCode.java
+++ b/src/main/java/com/googongill/aditory/common/code/SuccessCode.java
@@ -28,6 +28,7 @@ public enum SuccessCode {
     // Category
     GET_CATEGORY_LIST_SUCCESS(HttpStatus.OK, "카테고리 목록 조회에 성공했습니다."),
     GET_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 조회에 성공했습니다."),
+    GET_CATEGORY_PUBLIC_LIST_SUCCESS(HttpStatus.OK, "공개 카테고리 목록 조회에 성공했습니다."),
     UPDATE_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 수정에 성공했습니다."),
     DELETE_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 삭제에 성공했습니다."),
     // CategoryLike
@@ -42,9 +43,7 @@ public enum SuccessCode {
     // Link
     SAVE_LINK_SUCCESS(HttpStatus.CREATED, "링크 저장에 성공했습니다."),
     // Category
-    SAVE_CATEGORY_SUCCESS(HttpStatus.CREATED, "카테고리 저장에 성공했습니다."),
-
-    ;
+    SAVE_CATEGORY_SUCCESS(HttpStatus.CREATED, "카테고리 저장에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/googongill/aditory/controller/CategoryController.java
+++ b/src/main/java/com/googongill/aditory/controller/CategoryController.java
@@ -54,6 +54,11 @@ public class CategoryController {
         return ApiResponse.success(GET_CATEGORY_SUCCESS,
                 CategoryResponse.of(categoryService.getCategory(categoryId, principalDetails.getUserId())));
     }
+    @GetMapping("/categories/public")
+    public ResponseEntity<ApiResponse<CategoryPublicListResponse>> getPublicCategories(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiResponse.success(GET_CATEGORY_PUBLIC_LIST_SUCCESS,
+                CategoryPublicListResponse.of(categoryService.getPublicCategoryList(principalDetails.getUserId())));
+    }
 
     // ======= Update =======
 

--- a/src/main/java/com/googongill/aditory/controller/dto/category/CategoryPublicListResponse.java
+++ b/src/main/java/com/googongill/aditory/controller/dto/category/CategoryPublicListResponse.java
@@ -1,0 +1,23 @@
+package com.googongill.aditory.controller.dto.category;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.googongill.aditory.service.dto.category.CategoryInfo;
+import com.googongill.aditory.service.dto.category.CategoryPublicListResult;
+import lombok.Builder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@JsonSerialize
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class CategoryPublicListResponse {
+    List<CategoryInfo> categoryPublicList = new ArrayList<>();
+
+    public static CategoryPublicListResponse of(CategoryPublicListResult categoryPublicListResult) {
+        return CategoryPublicListResponse.builder()
+                .categoryPublicList(categoryPublicListResult.getCategoryPublicList())
+                .build();
+    }
+}

--- a/src/main/java/com/googongill/aditory/repository/CategoryRepository.java
+++ b/src/main/java/com/googongill/aditory/repository/CategoryRepository.java
@@ -1,9 +1,11 @@
 package com.googongill.aditory.repository;
 
 import com.googongill.aditory.domain.Category;
+import com.googongill.aditory.domain.enums.CategoryState;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
@@ -12,4 +14,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findById(Long id);
 
     Optional<Category> findByCategoryName(String categoryName);
+
+    Collection<Object> findAllByCategoryState(CategoryState categoryState);
 }

--- a/src/main/java/com/googongill/aditory/service/CategoryService.java
+++ b/src/main/java/com/googongill/aditory/service/CategoryService.java
@@ -64,6 +64,26 @@ public class CategoryService {
                 .collect(Collectors.toList());
         return CategoryListResult.of(categoryInfoList);
     }
+    public CategoryPublicListResult getPublicCategoryList(Long userId) {
+        // user 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+        // 모든 사용자 카테고리 중에서 state가 public 인 것만 조회
+        List<CategoryInfo> categoryPublicInfoList = categoryRepository.findAllByCategoryState(CategoryState.PUBLIC).stream()
+                .map(object -> {
+                    Category category = (Category) object;
+                    return CategoryInfo.builder()
+                            .categoryId(category.getId())
+                            .categoryName(category.getCategoryName())
+                            .linkCount(category.getLinks().size())
+                            .categoryState(category.getCategoryState())
+                            .createdAt(category.getCreatedAt())
+                            .lastModifiedAt(category.getLastModifiedAt())
+                            .build();
+                })
+                .collect(Collectors.toList());
+        return CategoryPublicListResult.of(categoryPublicInfoList);
+    }
 
     public CategoryResult getCategory(Long categoryId, Long userId) {
         // 카테고리 조회
@@ -98,4 +118,6 @@ public class CategoryService {
         categoryRepository.save(category);
         return UpdateCategoryResult.of(category);
     }
+
+
 }

--- a/src/main/java/com/googongill/aditory/service/dto/category/CategoryPublicListResult.java
+++ b/src/main/java/com/googongill/aditory/service/dto/category/CategoryPublicListResult.java
@@ -1,0 +1,18 @@
+package com.googongill.aditory.service.dto.category;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+@Getter
+@Builder
+public class CategoryPublicListResult {
+    List<CategoryInfo> categoryPublicList = new ArrayList<>();
+
+    public static CategoryPublicListResult of(List<CategoryInfo> categoryPublicList) {
+        return CategoryPublicListResult.builder()
+                .categoryPublicList(categoryPublicList)
+                .build();
+    }
+}


### PR DESCRIPTION
1. 공유 카테고리보다는 공개 카테고리라는 말이 더 맞나 싶어서 API랑 이런 것들 다 공개 카테고리라고 적어놨는데 원래 하던대로 공유가 나을까요?
2. 공유 카테고리에서의 카테고리 조회는 원래 구현되어있는 API를 쓰는 게 맞는 거 같아서 안했는데 어떻게 생각하시는지...